### PR TITLE
Improve dynamic text handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -697,22 +697,8 @@ const [dragBoxStart, setDragBoxStart] = useState<{ x: number, y: number, offsetX
     ));
   };
 
-  const handleTextBoxFontSizeIncrease = (id: string) => {
-    setTextBoxes(textBoxes.map(box => 
-      box.id === id ? { ...box, fontSize: Math.min(box.fontSize + 2, 72) } : box
-    ));
-  };
-
-  const handleTextBoxFontSizeDecrease = (id: string) => {
-    setTextBoxes(textBoxes.map(box => 
-      box.id === id ? { ...box, fontSize: Math.max(box.fontSize - 2, 8) } : box
-    ));
-  };
-
-  const handleTextBoxTextAlignChange = (id: string, align: 'left' | 'center' | 'right') => {
-    setTextBoxes(textBoxes.map(box => 
-      box.id === id ? { ...box, textAlign: align } : box
-    ));
+  const handleTextBoxTextAlignChange = (_id: string, _align: 'left' | 'center' | 'right') => {
+    // alignment controls removed
   };
 
   const handleTextBoxColorChange = (id: string, color: string) => {
@@ -740,11 +726,6 @@ const [dragBoxStart, setDragBoxStart] = useState<{ x: number, y: number, offsetX
     ));
   };
 
-  const handleShapeTextAlignChange = (id: string, align: 'left' | 'center' | 'right') => {
-    setShapes(shapes.map(shape => 
-      shape.id === id ? { ...shape, textAlign: align } : shape
-    ));
-  };
 
   const handleShapeTextColorChange = (id: string, color: string) => {
     setShapes(shapes.map(shape => 
@@ -1180,9 +1161,7 @@ const [dragBoxStart, setDragBoxStart] = useState<{ x: number, y: number, offsetX
             isBold={box.isBold}
             isItalic={box.isItalic}
             isUnderline={box.isUnderline}
-            textAlign={box.textAlign}
             color={box.color}
-            // ...removed unused props...
             onTextChange={handleTextChange}
             onTextBlur={handleTextBlur}
             onTextClick={(id, e) => {
@@ -1232,13 +1211,11 @@ const [dragBoxStart, setDragBoxStart] = useState<{ x: number, y: number, offsetX
                 isBold: shape.isBold,
                 isItalic: shape.isItalic,
                 isUnderline: shape.isUnderline,
-                textAlign: shape.textAlign || 'center',
                 color: shape.textColor || '#000000'
               }}
               onToggleBold={() => handleShapeToggleBold(shape.id)}
               onToggleItalic={() => handleShapeToggleItalic(shape.id)}
               onToggleUnderline={() => handleShapeToggleUnderline(shape.id)}
-              onTextAlignChange={(align) => handleShapeTextAlignChange(shape.id, align)}
               onColorChange={(color) => handleShapeTextColorChange(shape.id, color)}
               onChangeGradient={() => handleShapeChangeGradient(shape.id)}
               onDelete={() => handleShapeDelete(shape.id)}
@@ -1260,16 +1237,11 @@ const [dragBoxStart, setDragBoxStart] = useState<{ x: number, y: number, offsetX
                 isBold: textBox.isBold,
                 isItalic: textBox.isItalic,
                 isUnderline: textBox.isUnderline,
-                fontSize: textBox.fontSize,
-                textAlign: textBox.textAlign || 'center',
                 color: textBox.color || '#000000'
               }}
               onToggleBold={() => handleTextBoxToggleBold(textBox.id)}
               onToggleItalic={() => handleTextBoxToggleItalic(textBox.id)}
               onToggleUnderline={() => handleTextBoxToggleUnderline(textBox.id)}
-              onFontSizeIncrease={() => handleTextBoxFontSizeIncrease(textBox.id)}
-              onFontSizeDecrease={() => handleTextBoxFontSizeDecrease(textBox.id)}
-              onTextAlignChange={(align) => handleTextBoxTextAlignChange(textBox.id, align)}
               onColorChange={(color) => handleTextBoxColorChange(textBox.id, color)}
               onChangeGradient={() => {
                 const randomGradient = getRandomGradient();

--- a/src/FloatingToolbar.tsx
+++ b/src/FloatingToolbar.tsx
@@ -4,15 +4,10 @@ import {
   Trash2, 
   Copy, 
   RotateCcw, 
-  Bold, 
-  Italic, 
+  Bold,
+  Italic,
   Underline,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
   Type,
-  Plus,
-  Minus,
   ChevronDown
 } from 'lucide-react';
 
@@ -32,16 +27,11 @@ interface FloatingToolbarProps {
     isBold?: boolean;
     isItalic?: boolean;
     isUnderline?: boolean;
-    fontSize?: number;
-    textAlign?: 'left' | 'center' | 'right';
     color?: string;
   };
   onToggleBold?: () => void;
   onToggleItalic?: () => void;
   onToggleUnderline?: () => void;
-  onFontSizeIncrease?: () => void;
-  onFontSizeDecrease?: () => void;
-  onTextAlignChange?: (align: 'left' | 'center' | 'right') => void;
   onColorChange?: (color: string) => void;
 }
 
@@ -58,9 +48,6 @@ const FloatingToolbar: React.FC<FloatingToolbarProps> = ({
   onToggleBold,
   onToggleItalic,
   onToggleUnderline,
-  onFontSizeIncrease,
-  onFontSizeDecrease,
-  onTextAlignChange,
   onColorChange,
 }) => {
   const [showColorPicker, setShowColorPicker] = useState(false);
@@ -106,32 +93,6 @@ const FloatingToolbar: React.FC<FloatingToolbarProps> = ({
       {/* Text Formatting Controls - only for textbox and shapes */}
       {hasTextFormatting && (
         <>
-          {/* Font Size Controls */}
-          <div className="flex items-center border-r border-gray-200 pr-2 mr-2">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onFontSizeDecrease?.();
-              }}
-              className="p-1 rounded hover:bg-gray-100 transition-colors"
-              title="Decrease font size"
-            >
-              <Minus className="w-3 h-3 text-gray-600" />
-            </button>
-            <span className="mx-2 text-xs text-gray-600 min-w-[2rem] text-center">
-              {textStyle?.fontSize || 16}px
-            </span>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onFontSizeIncrease?.();
-              }}
-              className="p-1 rounded hover:bg-gray-100 transition-colors"
-              title="Increase font size"
-            >
-              <Plus className="w-3 h-3 text-gray-600" />
-            </button>
-          </div>
 
           {/* Text Style Controls */}
           <div className="flex items-center border-r border-gray-200 pr-2 mr-2 space-x-1">
@@ -179,51 +140,6 @@ const FloatingToolbar: React.FC<FloatingToolbarProps> = ({
             </button>
           </div>
 
-          {/* Text Alignment */}
-          <div className="flex items-center border-r border-gray-200 pr-2 mr-2 space-x-1">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onTextAlignChange?.('left');
-              }}
-              className={`p-1.5 rounded transition-colors ${
-                textStyle?.textAlign === 'left' 
-                  ? 'bg-blue-100 text-blue-600' 
-                  : 'hover:bg-gray-100 text-gray-600'
-              }`}
-              title="Align left"
-            >
-              <AlignLeft className="w-4 h-4" />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onTextAlignChange?.('center');
-              }}
-              className={`p-1.5 rounded transition-colors ${
-                textStyle?.textAlign === 'center' 
-                  ? 'bg-blue-100 text-blue-600' 
-                  : 'hover:bg-gray-100 text-gray-600'
-              }`}
-              title="Align center"
-            >
-              <AlignCenter className="w-4 h-4" />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onTextAlignChange?.('right');
-              }}
-              className={`p-1.5 rounded transition-colors ${
-                textStyle?.textAlign === 'right' 
-                  ? 'bg-blue-100 text-blue-600' 
-                  : 'hover:bg-gray-100 text-gray-600'
-              }`}
-              title="Align right"
-            >
-              <AlignRight className="w-4 h-4" />
-            </button>
-          </div>
 
           {/* Color Picker */}
           <div className="relative border-r border-gray-200 pr-2 mr-2">

--- a/src/TextBox.tsx
+++ b/src/TextBox.tsx
@@ -15,7 +15,6 @@ interface TextBoxProps {
   isBold?: boolean;
   isItalic?: boolean;
   isUnderline?: boolean;
-  textAlign?: 'left' | 'center' | 'right';
   color?: string;
   onTextChange: (id: string, newText: string) => void;
   onTextBlur: (id: string) => void;
@@ -27,7 +26,7 @@ interface TextBoxProps {
 
 const TextBox: React.FC<TextBoxProps> = ({
   id, x, y, width, height, text, gradient, isEditing, fontSize, selected,
-  isBold, isItalic, isUnderline, textAlign, color,
+  isBold, isItalic, isUnderline, color,
   onTextChange, onTextBlur, onTextClick, onTextDoubleClick, onMouseDown, onResizeStart
 }) => {
   // Build dynamic style classes and styles
@@ -38,15 +37,10 @@ const TextBox: React.FC<TextBoxProps> = ({
     isUnderline ? 'underline' : ''
   ].filter(Boolean).join(' ');
 
-  const alignmentClasses = {
-    left: 'justify-start text-left',
-    center: 'justify-center text-center', 
-    right: 'justify-end text-right'
-  };
 
   const textStyle = {
     fontSize: `${fontSize}px`,
-    wordWrap: 'break-word' as const,
+    whiteSpace: 'pre' as const,
     overflow: 'hidden' as const,
     color: color || 'transparent', // Use color if provided, otherwise transparent for gradient
   };
@@ -59,20 +53,19 @@ const TextBox: React.FC<TextBoxProps> = ({
       style={{ left: x, top: y, width, height }}
     >
       {isEditing ? (
-        <input
-          type="text"
+        <textarea
           value={text}
           onChange={e => onTextChange(id, e.target.value)}
           onBlur={() => onTextBlur(id)}
-          onKeyDown={e => { if (e.key === 'Enter') onTextBlur(id); }}
+          wrap="off"
           className="w-full h-full bg-transparent border-2 border-dashed border-gray-400 rounded px-2 py-1 font-bold focus:outline-none focus:border-blue-500 resize-none"
-          style={{ fontSize: `${fontSize}px` }}
+          style={{ fontSize: `${fontSize}px`, whiteSpace: 'pre' }}
           autoFocus
         />
       ) : (
         <div className="relative w-full h-full">
           <div
-            className={`${textClasses} ${alignmentClasses[textAlign || 'center']} ${gradientClasses}`}
+            className={`${textClasses} justify-center text-center ${gradientClasses}`}
             onClick={e => onTextClick(id, e)}
             onDoubleClick={() => onTextDoubleClick(id)}
             onMouseDown={e => onMouseDown(e, id)}

--- a/src/hooks/handleWhiteboardMouseMove.ts
+++ b/src/hooks/handleWhiteboardMouseMove.ts
@@ -128,7 +128,7 @@ export function handleWhiteboardMouseMove({
     const newWidth = Math.max(100, resizeStart.width + deltaX);
     const newHeight = Math.max(30, resizeStart.height + deltaY);
     const scaleFactor = Math.max(newWidth / resizeStart.width, newHeight / resizeStart.height);
-    const newFontSize = Math.max(12, Math.min(72, resizeStart.fontSize * scaleFactor));
+    const newFontSize = resizeStart.fontSize * scaleFactor;
     setTextBoxesResize((textBoxes: any[]) => textBoxes.map((box: any) =>
       box.id === resizingBox ? {
         ...box,

--- a/src/hooks/useTextBoxHandlers.ts
+++ b/src/hooks/useTextBoxHandlers.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { calculateFontSizeToFit } from '../utils/fontUtils';
 
 interface TextBox {
   id: string;
@@ -39,11 +40,13 @@ export function useTextBoxHandlers(textBoxes: TextBox[], setTextBoxes: (fn: any)
     }
   }, [setSelectedBoxes]);
 
-  // Change text
+  // Change text and adjust font size to always fit width
   const handleTextChange = useCallback((id: string, newText: string) => {
-    setTextBoxes((prev: TextBox[]) => prev.map(box => 
-      box.id === id ? { ...box, text: newText } : box
-    ));
+    setTextBoxes((prev: TextBox[]) => prev.map(box => {
+      if (box.id !== id) return box;
+      const newFont = calculateFontSizeToFit(newText, box.width);
+      return { ...box, text: newText, fontSize: newFont };
+    }));
   }, [setTextBoxes]);
 
   // Blur (finish editing)

--- a/src/utils/fontUtils.ts
+++ b/src/utils/fontUtils.ts
@@ -1,0 +1,11 @@
+export function calculateFontSizeToFit(text: string, width: number, fontFamily = 'sans-serif'): number {
+  const testSize = 100;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return testSize;
+  const longestLine = text.split('\n').reduce((a, b) => (b.length > a.length ? b : a), '');
+  ctx.font = `${testSize}px ${fontFamily}`;
+  const textWidth = ctx.measureText(longestLine || ' ').width;
+  if (textWidth === 0) return testSize;
+  return (testSize * width) / textWidth;
+}


### PR DESCRIPTION
## Summary
- add canvas-based font sizing utility
- remove font/alignment controls from floating toolbar
- use textarea editing and center text in `TextBox`
- scale font without min/max when resizing
- auto-fit text width on changes

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_687a8b59152c832aab0d6c44d1f83ff3