### PR TITLE
Add arrow drawing tool

### DIFF
--- a/src/ArrowElement.tsx
+++ b/src/ArrowElement.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+interface Gradient {
+  name: string;
+  value: string;
+  preview: string;
+}
+
+interface ArrowElementProps {
+  arrow: {
+    id: string;
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    gradient: Gradient;
+  };
+  selected: boolean;
+  onClick: (e: React.MouseEvent, id: string) => void;
+}
+
+const ArrowElement: React.FC<ArrowElementProps> = ({ arrow, selected, onClick }) => {
+  const stops = arrow.gradient.preview.match(/#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})/g) || ['#000'];
+  const gradientId = `arrow-gradient-${arrow.id}`;
+  const markerId = `arrowhead-${arrow.id}`;
+
+  return (
+    <svg
+      className="absolute inset-0 w-full h-full pointer-events-auto"
+      style={{ zIndex: 6, overflow: 'visible' }}
+      onClick={(e) => onClick(e, arrow.id)}
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
+          {stops.map((color, i) => (
+            <stop key={i} offset={`${(i / (stops.length - 1)) * 100}%`} stopColor={color} />
+          ))}
+        </linearGradient>
+        <marker
+          id={markerId}
+          markerWidth="10"
+          markerHeight="10"
+          refX="10"
+          refY="5"
+          orient="auto"
+          markerUnits="strokeWidth"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" fill={`url(#${gradientId})`} />
+        </marker>
+      </defs>
+      <line
+        x1={arrow.x1}
+        y1={arrow.y1}
+        x2={arrow.x2}
+        y2={arrow.y2}
+        stroke={`url(#${gradientId})`}
+        strokeWidth={2}
+        markerEnd={`url(#${markerId})`}
+        style={{ pointerEvents: 'stroke' }}
+      />
+      {selected && (
+        <line
+          x1={arrow.x1}
+          y1={arrow.y1}
+          x2={arrow.x2}
+          y2={arrow.y2}
+          stroke="#3b82f6"
+          strokeWidth={4}
+          markerEnd={`url(#${markerId})`}
+          strokeOpacity={0.3}
+          style={{ pointerEvents: 'none' }}
+        />
+      )}
+    </svg>
+  );
+};
+
+export default ArrowElement;

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Square, Circle, Diamond, Pen } from 'lucide-react';
+import { Square, Circle, Diamond, Pen, ArrowRight } from 'lucide-react';
 
 interface ToolbarProps {
-  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen';
-  setActiveTool: (tool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen') => void;
+  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen' | 'arrow';
+  setActiveTool: (tool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen' | 'arrow') => void;
 }
 
 const Toolbar: React.FC<ToolbarProps> = ({
@@ -49,6 +49,18 @@ const Toolbar: React.FC<ToolbarProps> = ({
         >
           <Diamond className="w-4 h-4" />
           <span className="text-sm font-medium">Diamond</span>
+        </button>
+        <button
+          onClick={() => setActiveTool('arrow')}
+          className={`flex items-center space-x-1 px-3 py-2 rounded-xl transition-colors ${
+            activeTool === 'arrow'
+              ? 'bg-blue-500 text-white shadow-sm'
+              : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+          }`}
+          title="Arrow Tool"
+        >
+          <ArrowRight className="w-4 h-4" />
+          <span className="text-sm font-medium">Arrow</span>
         </button>
         <button
           onClick={() => setActiveTool('pen')}

--- a/src/hooks/handleMouseUp.ts
+++ b/src/hooks/handleMouseUp.ts
@@ -6,6 +6,11 @@ interface HandleMouseUpParams {
   setDrawingPaths: (fn: any) => void;
   setCurrentPath: (val: any) => void;
   setIsDrawing: (val: boolean) => void;
+  isDrawingArrow: boolean;
+  currentArrow: any;
+  setArrows: (fn: any) => void;
+  setCurrentArrow: (val: any) => void;
+  setIsDrawingArrow: (val: boolean) => void;
   setResizingBox: (val: string | null) => void;
   setResizingShape: (val: string | null) => void;
   setResizingImage: (val: string | null) => void;
@@ -38,6 +43,11 @@ export function handleMouseUp({
   setDrawingPaths,
   setCurrentPath,
   setIsDrawing,
+  isDrawingArrow,
+  currentArrow,
+  setArrows,
+  setCurrentArrow,
+  setIsDrawingArrow,
   setResizingBox,
   setResizingShape,
   setResizingImage,
@@ -67,6 +77,11 @@ export function handleMouseUp({
     setDrawingPaths((prev: any[]) => [...prev, currentPath]);
     setCurrentPath(null);
     setIsDrawing(false);
+  }
+  if (isDrawingArrow && currentArrow) {
+    setArrows((prev: any[]) => [...prev, currentArrow]);
+    setCurrentArrow(null);
+    setIsDrawingArrow(false);
   }
   setResizingBox(null);
   setResizingShape(null);

--- a/src/hooks/handleWhiteboardMouseDown.ts
+++ b/src/hooks/handleWhiteboardMouseDown.ts
@@ -5,12 +5,14 @@ interface HandleWhiteboardMouseDownParams {
   whiteboardRef: React.RefObject<HTMLDivElement>;
   pan: { x: number; y: number };
   zoom: number;
-  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen';
+  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen' | 'arrow';
   setIsPanning: (val: boolean) => void;
   setPanStart: (val: { x: number; y: number } | null) => void;
   setMarquee: (val: { startX: number; startY: number; endX: number; endY: number } | null) => void;
   setIsDrawing: (val: boolean) => void;
   setCurrentPath: (path: any) => void;
+  setIsDrawingArrow: (val: boolean) => void;
+  setCurrentArrow: (arrow: any) => void;
   getRandomGradient: () => any;
 }
 
@@ -25,6 +27,8 @@ export function handleWhiteboardMouseDown({
   setMarquee,
   setIsDrawing,
   setCurrentPath,
+  setIsDrawingArrow,
+  setCurrentArrow,
   getRandomGradient
 }: HandleWhiteboardMouseDownParams) {
   if (e.button === 2) {
@@ -54,6 +58,19 @@ export function handleWhiteboardMouseDown({
           gradient: randomGradient
         };
         setCurrentPath(newPath);
+        return;
+      } else if (activeTool === 'arrow') {
+        setIsDrawingArrow(true);
+        const randomGradient = getRandomGradient();
+        const newArrow = {
+          id: Date.now().toString() + Math.random().toString(36).slice(2),
+          x1: x,
+          y1: y,
+          x2: x,
+          y2: y,
+          gradient: randomGradient
+        };
+        setCurrentArrow(newArrow);
         return;
       }
       setMarquee({ startX: x, startY: y, endX: x, endY: y });

--- a/src/hooks/handleWhiteboardMouseMove.ts
+++ b/src/hooks/handleWhiteboardMouseMove.ts
@@ -11,8 +11,11 @@ interface HandleWhiteboardMouseMoveParams {
   setPanStart: (val: { x: number; y: number } | null) => void;
   isDrawing: boolean;
   currentPath: any;
-  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen';
+  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen' | 'arrow';
   setCurrentPath: (path: any) => void;
+  isDrawingArrow: boolean;
+  currentArrow: any;
+  setCurrentArrow: (arrow: any) => void;
   draggingShape: string | null;
   dragShapeStart: { x: number; y: number; offsetX: number; offsetY: number } | null;
   setShapes: (fn: any) => void;
@@ -47,6 +50,9 @@ export function handleWhiteboardMouseMove({
   currentPath,
   activeTool,
   setCurrentPath,
+  isDrawingArrow,
+  currentArrow,
+  setCurrentArrow,
   draggingShape,
   dragShapeStart,
   setShapes,
@@ -84,6 +90,14 @@ export function handleWhiteboardMouseMove({
       ...prev,
       points: [...prev.points, { x, y }]
     } : null);
+    return;
+  }
+  if (isDrawingArrow && currentArrow && activeTool === 'arrow') {
+    const rect = whiteboardRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = (e.clientX - rect.left - pan.x) / zoom;
+    const y = (e.clientY - rect.top - pan.y) / zoom;
+    setCurrentArrow((prev: any) => prev ? { ...prev, x2: x, y2: y } : null);
     return;
   }
   if (draggingShape && dragShapeStart) {

--- a/src/hooks/useArrowHandlers.ts
+++ b/src/hooks/useArrowHandlers.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+
+interface Gradient {
+  name: string;
+  value: string;
+  preview: string;
+}
+
+interface Arrow {
+  id: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  gradient: Gradient;
+}
+
+export function useArrowHandlers(arrows: Arrow[], setArrows: (fn: any) => void, setSelectedArrows: (fn: any) => void) {
+  const handleArrowClick = useCallback((e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    if (e.ctrlKey || e.metaKey) {
+      setSelectedArrows((prev: string[]) =>
+        prev.includes(id) ? prev.filter(aid => aid !== id) : [...prev, id]
+      );
+    } else {
+      setSelectedArrows((prev: string[]) => (prev.length === 1 && prev[0] === id ? [] : [id]));
+    }
+  }, [setSelectedArrows]);
+
+  const handleArrowDelete = useCallback((id: string) => {
+    setArrows((prev: Arrow[]) => prev.filter(a => a.id !== id));
+  }, [setArrows]);
+
+  return {
+    handleArrowClick,
+    handleArrowDelete
+  };
+}

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -6,6 +6,7 @@ interface AutoSaveData {
   shapes: any[];
   images: any[];
   drawingPaths: any[];
+  arrows: any[];
   mindMapNodes: any[];
 }
 

--- a/src/hooks/useFirebaseWhiteboard.ts
+++ b/src/hooks/useFirebaseWhiteboard.ts
@@ -22,6 +22,7 @@ export interface WhiteboardData {
   shapes: any[];
   images: any[];
   drawingPaths: any[];
+  arrows: any[];
   mindMapNodes: any[];
   createdAt: Timestamp;
   updatedAt: Timestamp;
@@ -42,6 +43,7 @@ export const useFirebaseWhiteboard = () => {
       shapes: any[];
       images: any[];
       drawingPaths: any[];
+      arrows: any[];
       mindMapNodes: any[];
     }
   ): Promise<string | null> => {
@@ -109,6 +111,7 @@ export const useFirebaseWhiteboard = () => {
       shapes: any[];
       images: any[];
       drawingPaths: any[];
+      arrows: any[];
       mindMapNodes: any[];
     }
   ): Promise<boolean> => {
@@ -118,9 +121,10 @@ export const useFirebaseWhiteboard = () => {
       const updateData = {
         textBoxes: removeUndefined(whiteboardData.textBoxes),
         shapes: removeUndefined(whiteboardData.shapes),
-        images: removeUndefined(whiteboardData.images),
-        drawingPaths: removeUndefined(whiteboardData.drawingPaths),
-        mindMapNodes: removeUndefined(whiteboardData.mindMapNodes),
+      images: removeUndefined(whiteboardData.images),
+      drawingPaths: removeUndefined(whiteboardData.drawingPaths),
+      arrows: removeUndefined(whiteboardData.arrows),
+      mindMapNodes: removeUndefined(whiteboardData.mindMapNodes),
         updatedAt: Timestamp.now()
       };
       const docRef = doc(db, 'whiteboards', id);

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -2,17 +2,20 @@ import { useEffect } from 'react';
 
 
 interface UseKeyboardShortcutsProps {
-  setActiveTool: (tool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen') => void;
+  setActiveTool: (tool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen' | 'arrow') => void;
   setTextBoxes: React.Dispatch<React.SetStateAction<any[]>>;
   setShapes: React.Dispatch<React.SetStateAction<any[]>>;
   setSelectedBoxes: React.Dispatch<React.SetStateAction<string[]>>;
   setSelectedShapes: React.Dispatch<React.SetStateAction<string[]>>;
+  setArrows?: React.Dispatch<React.SetStateAction<any[]>>;
+  setSelectedArrows?: React.Dispatch<React.SetStateAction<string[]>>;
   lastMousePos: { x: number; y: number };
   selectedBoxes: string[];
   selectedShapes: string[];
+  selectedArrows?: string[];
   textBoxes: any[];
   shapes: any[];
-  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen';
+  activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen' | 'arrow';
   getRandomGradient: () => any;
   // Mind Map props
   activeMindMapNode: string | null;
@@ -33,9 +36,12 @@ export function useKeyboardShortcuts({
   setShapes,
   setSelectedBoxes,
   setSelectedShapes,
+  setArrows,
+  setSelectedArrows,
   lastMousePos,
   selectedBoxes,
   selectedShapes,
+  selectedArrows,
   textBoxes,
   shapes,
   activeTool,
@@ -66,6 +72,8 @@ export function useKeyboardShortcuts({
           setActiveTool('diamond');
         } else if (e.key === 'r' || e.key === 'R') {
           setActiveTool('pen');
+        } else if (e.key === 'a' || e.key === 'A') {
+          setActiveTool('arrow');
         } else if (e.key === 'b' || e.key === 'B') {
           // Toggle sidebar
           setSidebarOpen(prev => !prev);
@@ -117,7 +125,7 @@ export function useKeyboardShortcuts({
           }
         ]);
       }
-      if ((e.key === 'Delete' || e.key === 'Backspace') && !isInputFocused && !isEditingText && (selectedBoxes.length > 0 || selectedShapes.length > 0 || selectedMindMapNodes.length > 0)) {
+      if ((e.key === 'Delete' || e.key === 'Backspace') && !isInputFocused && !isEditingText && (selectedBoxes.length > 0 || selectedShapes.length > 0 || selectedMindMapNodes.length > 0 || (selectedArrows && selectedArrows.length > 0))) {
         e.preventDefault();
         
         // Delete selected text boxes
@@ -130,6 +138,11 @@ export function useKeyboardShortcuts({
         if (selectedShapes.length > 0) {
           setShapes(shapes => shapes.filter(shape => !selectedShapes.includes(shape.id)));
           setSelectedShapes([]);
+        }
+
+        if (selectedArrows && setArrows && setSelectedArrows && selectedArrows.length > 0) {
+          setArrows(arrows => arrows.filter((a: any) => !selectedArrows.includes(a.id)));
+          setSelectedArrows([]);
         }
         
         // Delete selected mind map nodes
@@ -197,5 +210,5 @@ export function useKeyboardShortcuts({
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [selectedBoxes, selectedShapes, selectedMindMapNodes, lastMousePos, textBoxes, shapes, activeTool, activeMindMapNode]);
+  }, [selectedBoxes, selectedShapes, selectedMindMapNodes, selectedArrows, lastMousePos, textBoxes, shapes, activeTool, activeMindMapNode]);
 }


### PR DESCRIPTION
## Summary
- add `ArrowElement` component and hooks for arrow handlers
- support arrow creation in mouse handlers
- track arrows in app state and auto-save
- extend keyboard shortcuts and toolbar with Arrow tool

## Testing
- `npm run lint` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_b_687a9c926d58832a9ee7960424ca478b