### PR TITLE
Add arrow drawing tool

### DIFF
--- a/src/ArrowElement.tsx
+++ b/src/ArrowElement.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export interface Arrow {
+  id: string;
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+}
+
+interface ArrowElementProps {
+  arrow: Arrow;
+  selected: boolean;
+  onClick: (e: React.MouseEvent, id: string) => void;
+  onMouseDown: (e: React.MouseEvent, id: string) => void;
+}
+
+const ArrowElement: React.FC<ArrowElementProps> = ({ arrow, selected, onClick, onMouseDown }) => {
+  const left = Math.min(arrow.startX, arrow.endX);
+  const top = Math.min(arrow.startY, arrow.endY);
+  const width = Math.abs(arrow.endX - arrow.startX) || 1;
+  const height = Math.abs(arrow.endY - arrow.startY) || 1;
+
+  const startX = arrow.startX - left;
+  const startY = arrow.startY - top;
+  const endX = arrow.endX - left;
+  const endY = arrow.endY - top;
+
+  const angle = Math.atan2(endY - startY, endX - startX);
+  const headLength = 10;
+  const arrowHead = `${endX},${endY} ${endX - headLength * Math.cos(angle - Math.PI / 6)},${endY - headLength * Math.sin(angle - Math.PI / 6)} ${endX - headLength * Math.cos(angle + Math.PI / 6)},${endY - headLength * Math.sin(angle + Math.PI / 6)}`;
+
+  return (
+    <div
+      className={`absolute${selected ? ' ring-2 ring-blue-400 z-20' : ''}`}
+      style={{ left, top, width, height }}
+      onClick={e => onClick(e, arrow.id)}
+      onMouseDown={e => onMouseDown(e, arrow.id)}
+    >
+      <svg className="w-full h-full" style={{ overflow: 'visible' }}>
+        <line x1={startX} y1={startY} x2={endX} y2={endY} stroke="black" strokeWidth={2} />
+        <polygon points={arrowHead} fill="black" />
+      </svg>
+    </div>
+  );
+};
+
+export default ArrowElement;

--- a/src/hooks/handleMouseUp.ts
+++ b/src/hooks/handleMouseUp.ts
@@ -6,6 +6,11 @@ interface HandleMouseUpParams {
   setDrawingPaths: (fn: any) => void;
   setCurrentPath: (val: any) => void;
   setIsDrawing: (val: boolean) => void;
+  isDrawingArrow?: boolean;
+  currentArrow?: any;
+  setArrows?: (fn: any) => void;
+  setCurrentArrow?: (val: any) => void;
+  setIsDrawingArrow?: (val: boolean) => void;
   setResizingBox: (val: string | null) => void;
   setResizingShape: (val: string | null) => void;
   setResizingImage: (val: string | null) => void;
@@ -18,6 +23,9 @@ interface HandleMouseUpParams {
   draggingImage: string | null;
   setDraggingImage: (val: string | null) => void;
   setDragImageStart: (val: any) => void;
+  draggingArrow?: string | null;
+  setDraggingArrow?: (val: string | null) => void;
+  setDragArrowStart?: (val: any) => void;
   isPanning: boolean;
   setIsPanning: (val: boolean) => void;
   setPanStart: (val: any) => void;
@@ -25,9 +33,11 @@ interface HandleMouseUpParams {
   whiteboardRef: RefObject<HTMLDivElement>;
   textBoxes: any[];
   shapes: any[];
+  arrows?: any[];
   mindMapNodes: any[];
   setSelectedBoxes: (val: string[]) => void;
   setSelectedShapes: (val: string[]) => void;
+  setSelectedArrows?: (val: string[]) => void;
   setSelectedMindMapNodes: (val: string[]) => void;
   setMarquee: (val: any) => void;
 }
@@ -38,6 +48,11 @@ export function handleMouseUp({
   setDrawingPaths,
   setCurrentPath,
   setIsDrawing,
+  isDrawingArrow,
+  currentArrow,
+  setArrows,
+  setCurrentArrow,
+  setIsDrawingArrow,
   setResizingBox,
   setResizingShape,
   setResizingImage,
@@ -50,6 +65,9 @@ export function handleMouseUp({
   draggingImage,
   setDraggingImage,
   setDragImageStart,
+  draggingArrow,
+  setDraggingArrow,
+  setDragArrowStart,
   isPanning,
   setIsPanning,
   setPanStart,
@@ -57,9 +75,11 @@ export function handleMouseUp({
   whiteboardRef,
   textBoxes,
   shapes,
+  arrows,
   mindMapNodes,
   setSelectedBoxes,
   setSelectedShapes,
+  setSelectedArrows,
   setSelectedMindMapNodes,
   setMarquee
 }: HandleMouseUpParams) {
@@ -67,6 +87,11 @@ export function handleMouseUp({
     setDrawingPaths((prev: any[]) => [...prev, currentPath]);
     setCurrentPath(null);
     setIsDrawing(false);
+  }
+  if (isDrawingArrow && currentArrow && setArrows && setCurrentArrow) {
+    setArrows((prev: any[]) => [...prev, currentArrow]);
+    setCurrentArrow(null);
+    if (setIsDrawingArrow) setIsDrawingArrow(false);
   }
   setResizingBox(null);
   setResizingShape(null);
@@ -82,6 +107,10 @@ export function handleMouseUp({
   if (draggingImage) {
     setDraggingImage(null);
     setDragImageStart(null);
+  }
+  if (draggingArrow && setDraggingArrow && setDragArrowStart) {
+    setDraggingArrow(null);
+    setDragArrowStart(null);
   }
   if (isPanning) {
     setIsPanning(false);
@@ -113,8 +142,16 @@ export function handleMouseUp({
       const ny2 = node.y + node.height;
       return nx2 > x1 && nx1 < x2 && ny2 > y1 && ny1 < y2;
     }).map((node: any) => node.id);
+    const selectedArrowIds = arrows ? arrows.filter((arrow: any) => {
+      const ax1 = Math.min(arrow.startX, arrow.endX);
+      const ay1 = Math.min(arrow.startY, arrow.endY);
+      const ax2 = Math.max(arrow.startX, arrow.endX);
+      const ay2 = Math.max(arrow.startY, arrow.endY);
+      return ax2 > x1 && ax1 < x2 && ay2 > y1 && ay1 < y2;
+    }).map((a: any) => a.id) : [];
     setSelectedBoxes(selectedBoxes);
     setSelectedShapes(selectedShapesIds);
+    if (setSelectedArrows) setSelectedArrows(selectedArrowIds);
     setSelectedMindMapNodes(selectedMindMapNodeIds);
     setMarquee(null);
   }

--- a/src/hooks/handleWhiteboardMouseDown.ts
+++ b/src/hooks/handleWhiteboardMouseDown.ts
@@ -11,6 +11,8 @@ interface HandleWhiteboardMouseDownParams {
   setMarquee: (val: { startX: number; startY: number; endX: number; endY: number } | null) => void;
   setIsDrawing: (val: boolean) => void;
   setCurrentPath: (path: any) => void;
+  setIsDrawingArrow: (val: boolean) => void;
+  setCurrentArrow: (arrow: any) => void;
   getRandomGradient: () => any;
 }
 
@@ -25,6 +27,8 @@ export function handleWhiteboardMouseDown({
   setMarquee,
   setIsDrawing,
   setCurrentPath,
+  setIsDrawingArrow,
+  setCurrentArrow,
   getRandomGradient
 }: HandleWhiteboardMouseDownParams) {
   if (e.button === 2) {
@@ -54,6 +58,17 @@ export function handleWhiteboardMouseDown({
           gradient: randomGradient
         };
         setCurrentPath(newPath);
+        return;
+      }
+      if (e.shiftKey) {
+        setIsDrawingArrow(true);
+        setCurrentArrow({
+          id: Date.now().toString() + Math.random().toString(36).slice(2),
+          startX: x,
+          startY: y,
+          endX: x,
+          endY: y
+        });
         return;
       }
       setMarquee({ startX: x, startY: y, endX: x, endY: y });

--- a/src/hooks/handleWhiteboardMouseMove.ts
+++ b/src/hooks/handleWhiteboardMouseMove.ts
@@ -13,6 +13,12 @@ interface HandleWhiteboardMouseMoveParams {
   currentPath: any;
   activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen';
   setCurrentPath: (path: any) => void;
+  isDrawingArrow: boolean;
+  currentArrow: any;
+  setCurrentArrow: (arrow: any) => void;
+  draggingArrow: string | null;
+  dragArrowStart: { startX:number; startY:number; endX:number; endY:number; mouseX:number; mouseY:number } | null;
+  setArrows: (fn: any) => void;
   draggingShape: string | null;
   dragShapeStart: { x: number; y: number; offsetX: number; offsetY: number } | null;
   setShapes: (fn: any) => void;
@@ -47,6 +53,12 @@ export function handleWhiteboardMouseMove({
   currentPath,
   activeTool,
   setCurrentPath,
+  isDrawingArrow,
+  currentArrow,
+  setCurrentArrow,
+  draggingArrow,
+  dragArrowStart,
+  setArrows,
   draggingShape,
   dragShapeStart,
   setShapes,
@@ -86,6 +98,14 @@ export function handleWhiteboardMouseMove({
     } : null);
     return;
   }
+  if (isDrawingArrow && currentArrow) {
+    const rect = whiteboardRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = (e.clientX - rect.left - pan.x) / zoom;
+    const y = (e.clientY - rect.top - pan.y) / zoom;
+    setCurrentArrow({ ...currentArrow, endX: x, endY: y });
+    return;
+  }
   if (draggingShape && dragShapeStart) {
     const rect = whiteboardRef.current?.getBoundingClientRect();
     if (!rect) return;
@@ -95,6 +115,20 @@ export function handleWhiteboardMouseMove({
       shape.id === draggingShape
         ? { ...shape, x: mouseX - dragShapeStart.offsetX, y: mouseY - dragShapeStart.offsetY }
         : shape
+    ));
+    return;
+  }
+  if (draggingArrow && dragArrowStart) {
+    const rect = whiteboardRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const mouseX = (e.clientX - rect.left - pan.x) / zoom;
+    const mouseY = (e.clientY - rect.top - pan.y) / zoom;
+    const dx = mouseX - dragArrowStart.mouseX;
+    const dy = mouseY - dragArrowStart.mouseY;
+    setArrows((prev: any[]) => prev.map((arrow: any) =>
+      arrow.id === draggingArrow
+        ? { ...arrow, startX: dragArrowStart.startX + dx, startY: dragArrowStart.startY + dy, endX: dragArrowStart.endX + dx, endY: dragArrowStart.endY + dy }
+        : arrow
     ));
     return;
   }

--- a/src/hooks/useArrowHandlers.ts
+++ b/src/hooks/useArrowHandlers.ts
@@ -1,0 +1,68 @@
+import { Dispatch, SetStateAction } from 'react';
+import { Arrow } from '../ArrowElement';
+
+interface UseArrowHandlersProps {
+  arrows: Arrow[];
+  setArrows: Dispatch<SetStateAction<Arrow[]>>;
+  setSelectedArrows: Dispatch<SetStateAction<string[]>>;
+  setSelectedBoxes: Dispatch<SetStateAction<string[]>>;
+  setSelectedShapes: Dispatch<SetStateAction<string[]>>;
+  setSelectedImages: Dispatch<SetStateAction<string[]>>;
+  whiteboardRef: React.RefObject<HTMLDivElement>;
+  pan: { x: number; y: number };
+  zoom: number;
+  setDraggingArrow: Dispatch<SetStateAction<string | null>>;
+  setDragArrowStart: Dispatch<SetStateAction<{ startX:number; startY:number; endX:number; endY:number; mouseX:number; mouseY:number } | null>>;
+}
+
+export function useArrowHandlers({
+  arrows,
+  setArrows,
+  setSelectedArrows,
+  setSelectedBoxes,
+  setSelectedShapes,
+  setSelectedImages,
+  whiteboardRef,
+  pan,
+  zoom,
+  setDraggingArrow,
+  setDragArrowStart
+}: UseArrowHandlersProps) {
+  const handleArrowClick = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    if (e.ctrlKey || e.metaKey) {
+      setSelectedArrows(prev => prev.includes(id) ? prev.filter(a => a !== id) : [...prev, id]);
+    } else {
+      setSelectedArrows(prev => (prev.length === 1 && prev[0] === id ? [] : [id]));
+      setSelectedBoxes([]);
+      setSelectedShapes([]);
+      setSelectedImages([]);
+    }
+  };
+
+  const handleArrowMouseDown = (e: React.MouseEvent, id: string) => {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+    const rect = whiteboardRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const arrow = arrows.find(a => a.id === id);
+    if (!arrow) return;
+    const mouseX = (e.clientX - rect.left - pan.x) / zoom;
+    const mouseY = (e.clientY - rect.top - pan.y) / zoom;
+    setDraggingArrow(id);
+    setDragArrowStart({
+      startX: arrow.startX,
+      startY: arrow.startY,
+      endX: arrow.endX,
+      endY: arrow.endY,
+      mouseX,
+      mouseY
+    });
+  };
+
+  const handleArrowDelete = (id: string) => {
+    setArrows(arrows => arrows.filter(a => a.id !== id));
+  };
+
+  return { handleArrowClick, handleArrowMouseDown, handleArrowDelete };
+}

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -6,6 +6,7 @@ interface AutoSaveData {
   shapes: any[];
   images: any[];
   drawingPaths: any[];
+  arrows: any[];
   mindMapNodes: any[];
 }
 
@@ -76,9 +77,9 @@ export const useAutoSave = (
     const currentData = currentDataRef.current;
     const currentTitle = currentTitleRef.current;
     
-    const hasContent = currentData.textBoxes.length > 0 || currentData.shapes.length > 0 || 
-                      currentData.images.length > 0 || currentData.drawingPaths.length > 0 || 
-                      currentData.mindMapNodes.length > 0;
+    const hasContent = currentData.textBoxes.length > 0 || currentData.shapes.length > 0 ||
+                      currentData.images.length > 0 || currentData.drawingPaths.length > 0 ||
+                      currentData.arrows.length > 0 || currentData.mindMapNodes.length > 0;
 
     if (!hasContent) return;
 

--- a/src/hooks/useFirebaseWhiteboard.ts
+++ b/src/hooks/useFirebaseWhiteboard.ts
@@ -22,6 +22,7 @@ export interface WhiteboardData {
   shapes: any[];
   images: any[];
   drawingPaths: any[];
+  arrows: any[];
   mindMapNodes: any[];
   createdAt: Timestamp;
   updatedAt: Timestamp;
@@ -42,6 +43,7 @@ export const useFirebaseWhiteboard = () => {
       shapes: any[];
       images: any[];
       drawingPaths: any[];
+      arrows: any[];
       mindMapNodes: any[];
     }
   ): Promise<string | null> => {
@@ -109,6 +111,7 @@ export const useFirebaseWhiteboard = () => {
       shapes: any[];
       images: any[];
       drawingPaths: any[];
+      arrows: any[];
       mindMapNodes: any[];
     }
   ): Promise<boolean> => {
@@ -118,11 +121,12 @@ export const useFirebaseWhiteboard = () => {
       const updateData = {
         textBoxes: removeUndefined(whiteboardData.textBoxes),
         shapes: removeUndefined(whiteboardData.shapes),
-        images: removeUndefined(whiteboardData.images),
-        drawingPaths: removeUndefined(whiteboardData.drawingPaths),
-        mindMapNodes: removeUndefined(whiteboardData.mindMapNodes),
-        updatedAt: Timestamp.now()
-      };
+      images: removeUndefined(whiteboardData.images),
+      drawingPaths: removeUndefined(whiteboardData.drawingPaths),
+      arrows: removeUndefined(whiteboardData.arrows),
+      mindMapNodes: removeUndefined(whiteboardData.mindMapNodes),
+      updatedAt: Timestamp.now()
+    };
       const docRef = doc(db, 'whiteboards', id);
       await updateDoc(docRef, updateData);
       setLoading(false);

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -5,13 +5,17 @@ interface UseKeyboardShortcutsProps {
   setActiveTool: (tool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen') => void;
   setTextBoxes: React.Dispatch<React.SetStateAction<any[]>>;
   setShapes: React.Dispatch<React.SetStateAction<any[]>>;
+  setArrows?: React.Dispatch<React.SetStateAction<any[]>>;
   setSelectedBoxes: React.Dispatch<React.SetStateAction<string[]>>;
   setSelectedShapes: React.Dispatch<React.SetStateAction<string[]>>;
+  setSelectedArrows?: React.Dispatch<React.SetStateAction<string[]>>;
   lastMousePos: { x: number; y: number };
   selectedBoxes: string[];
   selectedShapes: string[];
+  selectedArrows?: string[];
   textBoxes: any[];
   shapes: any[];
+  arrows?: any[];
   activeTool: 'text' | 'rectangle' | 'circle' | 'diamond' | 'pen';
   getRandomGradient: () => any;
   // Mind Map props
@@ -31,13 +35,17 @@ export function useKeyboardShortcuts({
   setActiveTool,
   setTextBoxes,
   setShapes,
+  setArrows,
   setSelectedBoxes,
   setSelectedShapes,
+  setSelectedArrows,
   lastMousePos,
   selectedBoxes,
   selectedShapes,
+  selectedArrows,
   textBoxes,
   shapes,
+  arrows,
   activeTool,
   getRandomGradient,
   activeMindMapNode,
@@ -117,7 +125,7 @@ export function useKeyboardShortcuts({
           }
         ]);
       }
-      if ((e.key === 'Delete' || e.key === 'Backspace') && !isInputFocused && !isEditingText && (selectedBoxes.length > 0 || selectedShapes.length > 0 || selectedMindMapNodes.length > 0)) {
+      if ((e.key === 'Delete' || e.key === 'Backspace') && !isInputFocused && !isEditingText && (selectedBoxes.length > 0 || selectedShapes.length > 0 || (selectedArrows && selectedArrows.length > 0) || selectedMindMapNodes.length > 0)) {
         e.preventDefault();
         
         // Delete selected text boxes
@@ -130,6 +138,12 @@ export function useKeyboardShortcuts({
         if (selectedShapes.length > 0) {
           setShapes(shapes => shapes.filter(shape => !selectedShapes.includes(shape.id)));
           setSelectedShapes([]);
+        }
+
+        // Delete selected arrows
+        if (selectedArrows && selectedArrows.length > 0 && setArrows && setSelectedArrows) {
+          setArrows(arrows => arrows.filter((a:any) => !selectedArrows.includes(a.id)));
+          setSelectedArrows([]);
         }
         
         // Delete selected mind map nodes


### PR DESCRIPTION
## Summary
- implement new `Arrow` element with selection and dragging
- add handlers for arrow creation via shift+drag
- update whiteboard save data to include arrows
- support marquee selection and deletion for arrows

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_b_687aaf3fb2ac832aa543a44a0e34fb21