### PR TITLE
Improve textbox resizing behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { useShapeHandlers } from './hooks/useShapeHandlers';
 import { useImageHandlers } from './hooks/useImageHandlers';
 import { useArrowHandlers } from './hooks/useArrowHandlers';
 import { useUniversalDragging } from './hooks/useUniversalDragging';
-import { calculateFontSizeToFit } from './utils/fontUtils';
+import { measureTextDimensions } from './utils/fontUtils';
 import WhiteboardCanvas from './WhiteboardCanvas';
 import TextBox from './TextBox';
 import ImageElement from './ImageElement';
@@ -720,11 +720,11 @@ function App() {
     setTextBoxes(textBoxes.map(box => {
       if (box.id !== id) return box;
       const newBold = !box.isBold;
-      const newFontSize = calculateFontSizeToFit(box.text, box.width, {
+      const dims = measureTextDimensions(box.text, box.fontSize, {
         isBold: newBold,
         isItalic: box.isItalic
       });
-      return { ...box, isBold: newBold, fontSize: newFontSize };
+      return { ...box, isBold: newBold, width: dims.width, height: dims.height };
     }));
   };
 
@@ -732,11 +732,11 @@ function App() {
     setTextBoxes(textBoxes.map(box => {
       if (box.id !== id) return box;
       const newItalic = !box.isItalic;
-      const newFontSize = calculateFontSizeToFit(box.text, box.width, {
+      const dims = measureTextDimensions(box.text, box.fontSize, {
         isBold: box.isBold,
         isItalic: newItalic
       });
-      return { ...box, isItalic: newItalic, fontSize: newFontSize };
+      return { ...box, isItalic: newItalic, width: dims.width, height: dims.height };
     }));
   };
 

--- a/src/hooks/handleWhiteboardMouseMove.ts
+++ b/src/hooks/handleWhiteboardMouseMove.ts
@@ -1,5 +1,4 @@
 import { MouseEvent } from 'react';
-import { calculateFontSizeToFit } from '../utils/fontUtils';
 
 interface HandleWhiteboardMouseMoveParams {
   e: MouseEvent;
@@ -144,8 +143,11 @@ export function handleWhiteboardMouseMove({
   if (resizingBox) {
     const deltaX = e.clientX - resizeStart.x;
     const deltaY = e.clientY - resizeStart.y;
-    const newWidth = Math.max(120, resizeStart.width + deltaX); // Increased minimum width
-    const newHeight = Math.max(30, resizeStart.height + deltaY);
+    const widthScale = (resizeStart.width + deltaX) / resizeStart.width;
+    const heightScale = (resizeStart.height + deltaY) / resizeStart.height;
+    const scale = Math.max(widthScale, heightScale);
+    const newWidth = Math.max(120, resizeStart.width * scale);
+    const newHeight = Math.max(30, resizeStart.height * scale);
     setTextBoxesResize((textBoxes: any[]) =>
       textBoxes.map((box: any) =>
         box.id === resizingBox
@@ -153,10 +155,7 @@ export function handleWhiteboardMouseMove({
               ...box,
               width: newWidth,
               height: newHeight,
-              fontSize: calculateFontSizeToFit(box.text, newWidth, {
-                isBold: box.isBold,
-                isItalic: box.isItalic
-              }),
+              fontSize: resizeStart.fontSize * scale,
             }
           : box
       )

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { measureTextDimensions } from '../utils/fontUtils';
 
 
 interface UseKeyboardShortcutsProps {
@@ -81,26 +82,30 @@ export function useKeyboardShortcuts({
       }
       if ((e.key === 't' || e.key === 'T') && !isInputFocused && !isEditingText) {
         const randomGradient = getRandomGradient();
-        setTextBoxes(boxes => [
-          ...boxes,
-          {
-            id: Date.now().toString(),
-            x: lastMousePos.x - 100,
-            y: lastMousePos.y - 20,
-            text: 'Text',
-            gradient: randomGradient.value,
-            isEditing: false,
-            fontSize: 32,
-            width: 200,
-            height: 40,
-            // Default formatting properties
-            isBold: false,
-            isItalic: false,
-            isUnderline: false,
-            textAlign: 'center',
-            color: undefined // Use gradient by default
-          }
-        ]);
+        setTextBoxes(boxes => {
+          const fontSize = 32;
+          const dims = measureTextDimensions('Text', fontSize);
+          return [
+            ...boxes,
+            {
+              id: Date.now().toString(),
+              x: lastMousePos.x - dims.width / 2,
+              y: lastMousePos.y - dims.height / 2,
+              text: 'Text',
+              gradient: randomGradient.value,
+              isEditing: false,
+              fontSize,
+              width: dims.width,
+              height: dims.height,
+              // Default formatting properties
+              isBold: false,
+              isItalic: false,
+              isUnderline: false,
+              textAlign: 'center',
+              color: undefined // Use gradient by default
+            }
+          ];
+        });
       }
       if ((e.key === 'd' || e.key === 'D') && !isInputFocused && !isEditingText) {
         e.preventDefault();

--- a/src/hooks/useTextBoxHandlers.ts
+++ b/src/hooks/useTextBoxHandlers.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { calculateFontSizeToFit } from '../utils/fontUtils';
+import { measureTextDimensions } from '../utils/fontUtils';
 
 interface TextBox {
   id: string;
@@ -40,15 +40,15 @@ export function useTextBoxHandlers(setTextBoxes: (fn: any) => void, setSelectedB
     }
   }, [setSelectedBoxes]);
 
-  // Change text and adjust font size to always fit width
+  // Change text and expand box to fit new content without wrapping
   const handleTextChange = useCallback((id: string, newText: string) => {
     setTextBoxes((prev: TextBox[]) => prev.map(box => {
       if (box.id !== id) return box;
-      const newFont = calculateFontSizeToFit(newText, box.width, {
+      const dims = measureTextDimensions(newText, box.fontSize, {
         isBold: box.isBold,
-        isItalic: box.isItalic
+        isItalic: box.isItalic,
       });
-      return { ...box, text: newText, fontSize: newFont };
+      return { ...box, text: newText, width: dims.width, height: dims.height };
     }));
   }, [setTextBoxes]);
 

--- a/src/utils/fontUtils.ts
+++ b/src/utils/fontUtils.ts
@@ -71,3 +71,40 @@ export function calculateFontSizeToFit(
   
   return result;
 }
+
+export function measureTextDimensions(
+  text: string,
+  fontSize: number,
+  options: {
+    fontFamily?: string;
+    isBold?: boolean;
+    isItalic?: boolean;
+    lineHeight?: number;
+    padding?: number;
+  } = {}
+): { width: number; height: number } {
+  const {
+    fontFamily = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    isBold = false,
+    isItalic = false,
+    lineHeight = 1.1,
+    padding = 16,
+  } = options;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return { width: 0, height: 0 };
+
+  const fontWeight = isBold ? 'bold' : 'normal';
+  const fontStyle = isItalic ? 'italic' : 'normal';
+  ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
+
+  const lines = text.split('\n');
+  const widths = lines.map(line => ctx.measureText(line).width);
+  const maxWidth = widths.length > 0 ? Math.max(...widths) : 0;
+
+  return {
+    width: maxWidth + padding,
+    height: lines.length * fontSize * lineHeight + padding,
+  };
+}


### PR DESCRIPTION
## Summary
- add `measureTextDimensions` helper for measuring text
- auto-resize text boxes when editing text
- size new text boxes based on measured text
- keep aspect ratio when resizing and scale font size
- update bold/italic toggles to resize box instead of scaling font

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_687ad1daca84832abe5d89a2bef7dfee