### PR TITLE
Load last saved whiteboard on login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ import AuthModal from './components/AuthModal';
 
 function App() {
   const { user, loading: authLoading, error: authError } = useFirebaseAuth();
-  const { updateWhiteboardTitle } = useFirebaseWhiteboard();
+  const { updateWhiteboardTitle, getAllWhiteboards } = useFirebaseWhiteboard();
   
   // Debug user state
   React.useEffect(() => {
@@ -866,6 +866,27 @@ function App() {
     }
     // For new whiteboards, the title will be used when auto-save creates the whiteboard
   };
+
+  // Load the most recently updated whiteboard when a user logs in
+  React.useEffect(() => {
+    const loadLastWhiteboard = async () => {
+      if (!user || currentWhiteboardId) return;
+      const boards = await getAllWhiteboards(user);
+      if (boards.length > 0) {
+        handleLoadWhiteboard(boards[0]);
+      } else {
+        handleNewWhiteboard();
+      }
+    };
+
+    if (!authLoading) {
+      if (user) {
+        loadLastWhiteboard();
+      } else {
+        handleNewWhiteboard();
+      }
+    }
+  }, [user, authLoading]);
 
   return (
     <div className="min-h-screen bg-gray-50 relative overflow-hidden">


### PR DESCRIPTION
## Summary
- when logging in, fetch the user's whiteboards and load the most recently updated one
- fall back to a new whiteboard when the user has none

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_687ae1e61658832aaea3c710cdd3317f